### PR TITLE
Start updating to ZUGFeRD 2.3: Updated specification level URIs for Basic, En16931, and Extended

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,4 +92,4 @@ Please check `main.rs` for further examples.
 - [ ] embedding the generated XML into PDF/A-3 files
 ## Further reading
 
-[ZUGFeRD 2.2 specification](https://www.ferd-net.de/standards/zugferd-2.2/index.html)
+[ZUGFeRD 2.3 specification](https://www.ferd-net.de/standards/zugferd-2.3/zugferd-2.3.html)

--- a/src/components/enums/country_code.rs
+++ b/src/components/enums/country_code.rs
@@ -1,6 +1,6 @@
 use serde::{Serialize,Serializer};
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Debug)]
 pub enum CountryCode {
     NotSet,
     Germany,

--- a/src/components/enums/invoice_type_code.rs
+++ b/src/components/enums/invoice_type_code.rs
@@ -1,6 +1,6 @@
 use serde::{Serialize, Serializer};
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Debug)]
 pub enum InvoiceTypeCode {
     CommercialInvoice,
     CreditNote,

--- a/src/components/enums/specification_level.rs
+++ b/src/components/enums/specification_level.rs
@@ -14,9 +14,9 @@ impl SpecificationLevel {
         match self {
             SpecificationLevel::Minimum => "urn:factur-x.eu:1p0:minimum",
             SpecificationLevel::BasicWithoutLines => "urn:factur-x.eu:1p0:basicwl",
-            SpecificationLevel::Basic => "urn:factur-x.eu:1p0:basic",
-            SpecificationLevel::En16931 => "urn:factur-x.eu:1p0:en16931",
-            SpecificationLevel::Extended => "urn:factur-x.eu:1p0:extended",
+            SpecificationLevel::Basic => "urn:cen.eu:en16931:2017#compliant#urn:factur-x.eu:1p0:basic",
+            SpecificationLevel::En16931 => "urn:cen.eu:en16931:2017",
+            SpecificationLevel::Extended => "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended",
         }
     }
 }

--- a/src/components/enums/vat_category_code.rs
+++ b/src/components/enums/vat_category_code.rs
@@ -1,6 +1,6 @@
 use serde::{Serialize,Serializer};
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Debug)]
 pub enum VATCategoryCode {
     StandardRate,
     ZeroRatedGoods,

--- a/src/components/structs.rs
+++ b/src/components/structs.rs
@@ -213,8 +213,16 @@ impl <'invoice> GlobalID<'invoice> {
 
 #[derive(Serialize, Clone, Debug)]
 pub struct SpecifiedLineTradeAgreement {
+    #[serde(rename="ram:GrossPriceProductTradePrice")]
+    pub gross_price_product_trade_price: Option<GrossPriceProductTradePrice>,
     #[serde(rename="ram:NetPriceProductTradePrice")]
     pub net_price_product_trade_price: NetPriceProductTradePrice,
+}
+
+#[derive(Serialize, Clone, Debug)]
+pub struct GrossPriceProductTradePrice {
+    #[serde(rename="ram:ChargeAmount",serialize_with="f64_format")]
+    pub charge_amount: f64,
 }
 
 #[derive(Serialize, Clone, Debug)]

--- a/src/components/structs.rs
+++ b/src/components/structs.rs
@@ -42,7 +42,7 @@ fn vector_is_empty <S> (vector: &Vec<S>) -> bool {
 }
 
 //Specifications
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 #[serde(rename="rsm:CrossIndustryInvoice")]
 pub struct Invoice<'invoice> {
     //Namespaces
@@ -87,7 +87,7 @@ impl<'invoice> Invoice<'invoice> {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 pub struct DocumentContext<'invoice> {
     #[serde(rename="ram:BusinessProcessSpecifiedDocumentContextParameter")]
     pub business_process: BusinessProcess<'invoice>,
@@ -95,7 +95,7 @@ pub struct DocumentContext<'invoice> {
     pub guideline: Guideline,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 pub struct Document<'invoice> {
     #[serde(rename="ram:ID")]
     pub id: &'invoice str,
@@ -107,25 +107,25 @@ pub struct Document<'invoice> {
     pub included_note: Option<Vec<IncludedNote>>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone, Debug)]
 pub struct BusinessProcess<'invoice> {
     #[serde(rename="ram:ID")]
     pub id: &'invoice str,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone, Debug)]
 pub struct Guideline {
     #[serde(rename="ram:ID")]
     pub id: SpecificationLevel,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone, Debug)]
 pub struct IssueDateTime<'invoice> {
     #[serde(rename="udt:DateTimeString")]
     pub date_time_string: DateTimeString<'invoice>,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Clone, Debug)]
 pub struct DateTimeString<'invoice> {
     #[serde(rename="@format")]
     format: &'invoice str,
@@ -142,13 +142,13 @@ impl<'invoice> DateTimeString<'invoice> {
     }
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Clone, Debug)]
 pub struct IncludedNote {
     #[serde(rename="ram:Content")]
     pub content: String,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone, Debug)]
 pub struct SupplyChainTradeTransaction<'invoice> {
     #[serde(rename="ram:ApplicableHeaderTradeAgreement")]
     pub applicable_header_trade_agreement: ApplicableHeaderTradeAgreement<'invoice>,
@@ -160,7 +160,7 @@ pub struct SupplyChainTradeTransaction<'invoice> {
     pub included_supply_chain_trade_line_items: Vec<IncludedSupplyChainTradeLineItem<'invoice>>,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Clone, Debug)]
 pub struct IncludedSupplyChainTradeLineItem<'invoice> {
     #[serde(rename="ram:AssociatedDocumentLineDocument")]
     pub associated_document_line_document: AssociatedDocumentLineDocument<'invoice>,
@@ -174,13 +174,13 @@ pub struct IncludedSupplyChainTradeLineItem<'invoice> {
     pub specified_line_trade_settlement: SpecifiedLineTradeSettlement<'invoice>,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Clone, Debug)]
 pub struct AssociatedDocumentLineDocument<'invoice> {
     #[serde(rename="ram:LineID")]
     pub line_id: &'invoice str,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Clone, Debug)]
 pub struct SpecifiedTradeProduct<'invoice> {
     #[serde(rename="ram:GlobalID")]
     pub global_id: GlobalID<'invoice>,
@@ -190,7 +190,7 @@ pub struct SpecifiedTradeProduct<'invoice> {
     //pub description: &'invoice str,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Clone, Debug)]
 pub struct GlobalID<'invoice> {
     #[serde(rename="@schemeID")]
     pub scheme_id: IdentifierSchemeCode,
@@ -207,25 +207,25 @@ impl <'invoice> GlobalID<'invoice> {
     }
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Clone, Debug)]
 pub struct SpecifiedLineTradeAgreement {
     #[serde(rename="ram:NetPriceProductTradePrice")]
     pub net_price_product_trade_price: NetPriceProductTradePrice,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Clone, Debug)]
 pub struct NetPriceProductTradePrice {
     #[serde(rename="ram:ChargeAmount",serialize_with="f64_format")]
     pub charge_amount: f64,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Clone, Debug)]
 pub struct SpecifiedLineTradeDelivery {
     #[serde(rename="ram:BilledQuantity")]
     pub billed_quantity: BilledQuantity,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Clone, Debug)]
 pub struct BilledQuantity {
     #[serde(rename="@unitCode")]
     pub unit_code: UnitCode,
@@ -243,7 +243,7 @@ impl BilledQuantity {
     
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Clone, Debug)]
 pub struct SpecifiedLineTradeSettlement<'invoice> {
     #[serde(rename="ram:ApplicableTradeTax", skip_serializing_if = "Option::is_none")]
     pub applicable_trade_tax: Option<ApplicableTradeTax<'invoice>>,
@@ -251,13 +251,13 @@ pub struct SpecifiedLineTradeSettlement<'invoice> {
     pub specified_trade_settlement_line_monetary_summation: SpecifiedTradeSettlementLineMonetarySummation,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Clone, Debug)]
 pub struct SpecifiedTradeSettlementLineMonetarySummation {
     #[serde(rename="ram:LineTotalAmount", serialize_with="f64_format")]
     pub line_total_amount: f64,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone, Debug)]
 pub struct ApplicableHeaderTradeAgreement<'invoice> {
     #[serde(rename="ram:BuyerReference")]
     pub buyer_reference: &'invoice str,
@@ -269,7 +269,7 @@ pub struct ApplicableHeaderTradeAgreement<'invoice> {
     pub buyer_order_referenced_document: BuyerOrderReferencedDocument<'invoice>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone, Debug)]
 pub struct SellerTradeParty<'invoice> {
     #[serde(rename="ram:Name")]
     pub name: &'invoice str,
@@ -281,7 +281,7 @@ pub struct SellerTradeParty<'invoice> {
     pub specified_tax_registration: SpecifiedTaxRegistration<'invoice>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone, Debug)]
 pub struct LegalOrganizationID<'invoice> {
     #[serde(rename = "@schemeID")]
     scheme_id: &'static str,
@@ -298,13 +298,13 @@ impl<'invoice> LegalOrganizationID<'invoice> {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone, Debug)]
 pub struct SpecifiedLegalOrganization<'invoice> {
     #[serde(rename="ram:ID")]
     pub id: LegalOrganizationID<'invoice>,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Clone, Debug)]
 pub struct PostalTradeAddress <'invoice> {
 
     #[serde(rename="ram:PostcodeCode", skip_serializing_if = "Option::is_none")]
@@ -335,7 +335,7 @@ impl<'invoice> Default for PostalTradeAddress<'invoice> {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone, Debug)]
 pub struct SpecifiedTaxRegistrationID<'invoice> {
     #[serde(rename = "@schemeID")]
     scheme_id: &'static str,
@@ -352,13 +352,13 @@ impl<'invoice> SpecifiedTaxRegistrationID<'invoice> {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone, Debug)]
 pub struct SpecifiedTaxRegistration<'invoice> {
     #[serde(rename="ram:ID")]
     pub id: SpecifiedTaxRegistrationID<'invoice>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone, Debug)]
 pub struct BuyerTradeParty<'invoice> {
     #[serde(rename="ram:Name")]
     pub name: &'invoice str,
@@ -368,19 +368,19 @@ pub struct BuyerTradeParty<'invoice> {
     pub specified_legal_organization: SpecifiedLegalOrganization<'invoice>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone, Debug)]
 pub struct BuyerOrderReferencedDocument<'invoice> {
     #[serde(rename="ram:IssuerAssignedID")]
     pub issuer_assigned_id: &'invoice str,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone, Debug)]
 pub struct ApplicableHeaderTradeDelivery<'invoice> {
     #[serde(rename="ram:ActualDeliverySupplyChainEvent", skip_serializing_if = "Option::is_none")]
     pub actual_delivery_supply_chain_event: Option<ActualDeliverySupplyChainEvent<'invoice>>,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Clone, Debug)]
 pub struct ActualDeliverySupplyChainEvent<'invoice> {
     #[serde(rename="ram:OccurrenceDateTime", skip_serializing_if = "Option::is_none")]
     pub occurrence_date_time: Option<DateTimeString<'invoice>>,
@@ -400,7 +400,7 @@ impl<'invoice> ApplicableHeaderTradeDelivery<'invoice> {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone, Debug)]
 pub struct ApplicableHeaderTradeSettlement <'invoice>{
     #[serde(rename="ram:InvoiceCurrencyCode")]
     pub invoice_currency_code: CurrencyCode,
@@ -412,7 +412,7 @@ pub struct ApplicableHeaderTradeSettlement <'invoice>{
     pub specified_trade_payment_terms: Option<SpecifiedTradePaymentTerms<'invoice>>,
 }   
 
-#[derive(Serialize, Clone, Copy)]
+#[derive(Serialize, Clone, Copy, Debug)]
 pub struct ApplicableTradeTax <'invoice> {
     #[serde(rename="ram:CalculatedAmount",serialize_with="format_f64_option")]
     pub calculated_amount: Option<f64>,
@@ -439,13 +439,13 @@ impl<'invoice> Default for ApplicableTradeTax<'invoice> {
     }
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Clone, Debug)]
 pub struct SpecifiedTradePaymentTerms <'invoice> {
     #[serde(rename="ram:DueDateTime")]
     pub due_date_time: DateTimeString<'invoice>,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Clone, Debug)]
 pub struct SpecifiedTradeSettlementHeaderMonetarySummation {
     #[serde(rename="ram:LineTotalAmount", serialize_with="format_f64_option", skip_serializing_if = "Option::is_none")]
     pub line_total_amount: Option<f64>,
@@ -479,7 +479,7 @@ impl Default for SpecifiedTradeSettlementHeaderMonetarySummation {
     }
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Clone, Debug)]
 pub struct TaxTotalAmount {
     #[serde(rename="@currencyID")]
     pub currency_id: CurrencyCode,

--- a/src/components/structs.rs
+++ b/src/components/structs.rs
@@ -178,6 +178,9 @@ pub struct IncludedSupplyChainTradeLineItem<'invoice> {
 pub struct AssociatedDocumentLineDocument<'invoice> {
     #[serde(rename="ram:LineID")]
     pub line_id: &'invoice str,
+    #[serde(rename="ram:IncludedNote", skip_serializing_if = "Option::is_none")]
+    /// BT-127-00
+    pub included_note: Option<&'invoice str>,
 }
 
 #[derive(Serialize, Clone, Debug)]

--- a/src/components/structs.rs
+++ b/src/components/structs.rs
@@ -257,8 +257,8 @@ impl BilledQuantity {
 
 #[derive(Serialize, Clone, Debug)]
 pub struct SpecifiedLineTradeSettlement<'invoice> {
-    #[serde(rename="ram:ApplicableTradeTax", skip_serializing_if = "Option::is_none")]
-    pub applicable_trade_tax: Option<ApplicableTradeTax<'invoice>>,
+    #[serde(rename="ram:ApplicableTradeTax")]
+    pub applicable_trade_tax: ApplicableTradeTax<'invoice>,
     #[serde(rename="ram:SpecifiedTradeSettlementLineMonetarySummation")]
     pub specified_trade_settlement_line_monetary_summation: SpecifiedTradeSettlementLineMonetarySummation,
 }

--- a/src/components/structs.rs
+++ b/src/components/structs.rs
@@ -185,8 +185,9 @@ pub struct AssociatedDocumentLineDocument<'invoice> {
 
 #[derive(Serialize, Clone, Debug)]
 pub struct SpecifiedTradeProduct<'invoice> {
-    #[serde(rename="ram:GlobalID")]
-    pub global_id: GlobalID<'invoice>,
+    #[serde(rename="ram:GlobalID", skip_serializing_if = "Option::is_none")]
+    /// BT-157
+    pub global_id: Option<GlobalID<'invoice>>,
     #[serde(rename="ram:Name")]
     pub name: &'invoice str,
     //#[serde(rename="ram:Description")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,7 +103,10 @@ fn main() {
 
     //Going even further with Basic specification
     invoice_builder.add_supply_chain_trade_line_item(IncludedSupplyChainTradeLineItem {
-        associated_document_line_document:AssociatedDocumentLineDocument { line_id: "1" },
+        associated_document_line_document:AssociatedDocumentLineDocument {
+            line_id: "1",
+            included_note: None,
+        },
         specified_trade_product:SpecifiedTradeProduct {
             global_id: GlobalID {
                 value: "1234567890123",
@@ -137,7 +140,10 @@ fn main() {
     });
 
     invoice_builder.add_supply_chain_trade_line_item(IncludedSupplyChainTradeLineItem {
-        associated_document_line_document:AssociatedDocumentLineDocument { line_id: "1" },
+        associated_document_line_document:AssociatedDocumentLineDocument {
+            line_id: "1",
+            included_note: None,
+        },
         specified_trade_product:SpecifiedTradeProduct {
             global_id: GlobalID {
                 value: "2546585465423",

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,13 +127,13 @@ fn main() {
             },
         },
         specified_line_trade_settlement:SpecifiedLineTradeSettlement {
-            applicable_trade_tax: Some(ApplicableTradeTax {
+            applicable_trade_tax: ApplicableTradeTax {
                 calculated_amount: Some(19.0),
                 type_code: "VAT",
                 category_code: zugferd::VATCategoryCode::StandardRate,
                 basis_amount: Some(100.0),
                 rate_applicable_percent: Some(19.0),
-            }),
+            },
             specified_trade_settlement_line_monetary_summation: SpecifiedTradeSettlementLineMonetarySummation {
                 line_total_amount: 119.0,
             },
@@ -165,13 +165,13 @@ fn main() {
             },
         },
         specified_line_trade_settlement:SpecifiedLineTradeSettlement {
-            applicable_trade_tax: Some(ApplicableTradeTax {
+            applicable_trade_tax: ApplicableTradeTax {
                 calculated_amount: Some(0.44*19.0),
                 type_code: "VAT",
                 category_code: zugferd::VATCategoryCode::StandardRate,
                 basis_amount: Some(44.0),
                 rate_applicable_percent: Some(19.0),
-            }),
+            },
             specified_trade_settlement_line_monetary_summation: SpecifiedTradeSettlementLineMonetarySummation {
                 line_total_amount: (44.0*1.19),
             },

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,6 +115,7 @@ fn main() {
             name: "Product 1",
         },
         specified_line_trade_agreement:SpecifiedLineTradeAgreement {
+            gross_price_product_trade_price: None,
             net_price_product_trade_price: NetPriceProductTradePrice {
                 charge_amount: 100.0,
             },
@@ -152,6 +153,7 @@ fn main() {
             name: "Product 2",
         },
         specified_line_trade_agreement:SpecifiedLineTradeAgreement {
+            gross_price_product_trade_price: None,
             net_price_product_trade_price: NetPriceProductTradePrice {
                 charge_amount: 1.0,
             },

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,10 +108,10 @@ fn main() {
             included_note: None,
         },
         specified_trade_product:SpecifiedTradeProduct {
-            global_id: GlobalID {
+            global_id: Some(GlobalID {
                 value: "1234567890123",
                 scheme_id: IdentifierSchemeCode::GTIN,
-            },
+            }),
             name: "Product 1",
         },
         specified_line_trade_agreement:SpecifiedLineTradeAgreement {
@@ -145,10 +145,10 @@ fn main() {
             included_note: None,
         },
         specified_trade_product:SpecifiedTradeProduct {
-            global_id: GlobalID {
+            global_id: Some(GlobalID {
                 value: "2546585465423",
                 scheme_id: IdentifierSchemeCode::GTIN,
-            },
+            }),
             name: "Product 2",
         },
         specified_line_trade_agreement:SpecifiedLineTradeAgreement {


### PR DESCRIPTION
The current ZUGFeRD version (2.3) lists slightly different values for BT-24 (/rsm:CrossIndustryInvoice/rsm:ExchangedDocumentContext/ram:GuidelineSpecifiedDocumentContextParameter/ram:ID)