### PR TITLE
Delivery date-time has to be wrapped further

### DIFF
--- a/src/components/structs.rs
+++ b/src/components/structs.rs
@@ -395,7 +395,13 @@ pub struct ApplicableHeaderTradeDelivery<'invoice> {
 #[derive(Serialize, Clone, Debug)]
 pub struct ActualDeliverySupplyChainEvent<'invoice> {
     #[serde(rename="ram:OccurrenceDateTime", skip_serializing_if = "Option::is_none")]
-    pub occurrence_date_time: Option<DateTimeString<'invoice>>,
+    pub occurrence_date_time: Option<OccurrenceDateTime<'invoice>>,
+}
+
+#[derive(Serialize, Clone, Debug)]
+pub struct OccurrenceDateTime<'invoice> {
+    #[serde(rename="udt:DateTimeString")]
+    pub actual_delivery_date: DateTimeString<'invoice>,
 }
 
 impl<'invoice> ApplicableHeaderTradeDelivery<'invoice> {
@@ -403,7 +409,9 @@ impl<'invoice> ApplicableHeaderTradeDelivery<'invoice> {
         Self {
             actual_delivery_supply_chain_event: if occurrence_date_time.is_some() {
                 Some(ActualDeliverySupplyChainEvent {
-                    occurrence_date_time
+                    occurrence_date_time: occurrence_date_time.map(|actual_delivery_date| OccurrenceDateTime {
+                        actual_delivery_date,
+                    })
                 })
             } else {
                 None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -533,7 +533,11 @@ impl<'invoice_builder> InvoiceBuilder <'invoice_builder> {
                 },
                 applicable_header_trade_delivery: ApplicableHeaderTradeDelivery {
                     actual_delivery_supply_chain_event: Some(ActualDeliverySupplyChainEvent {
-                        occurrence_date_time: self.occurrence_date.clone(),
+                        occurrence_date_time: self.occurrence_date.clone().map(|actual_delivery_date|
+                            OccurrenceDateTime {
+                                actual_delivery_date,
+                            }
+                        ),
                     }),
                 },
                 applicable_header_trade_settlement: ApplicableHeaderTradeSettlement {


### PR DESCRIPTION
XML should look like (from the official zugferd example files)
```xml
<ram:ActualDeliverySupplyChainEvent>
  <ram:OccurrenceDateTime>
    <udt:DateTimeString format="102">20241114</udt:DateTimeString>
  </ram:OccurrenceDateTime>
</ram:ActualDeliverySupplyChainEvent>
```
but previously this was generated:
```xml
<ram:ActualDeliverySupplyChainEvent>
  <ram:OccurrenceDateTime format="102">20240102</ram:OccurrenceDateTime>
</ram:ActualDeliverySupplyChainEvent>
```