### PR TITLE
make structs more closely resemble the spec

### DIFF
--- a/src/components/enums/mod.rs
+++ b/src/components/enums/mod.rs
@@ -5,3 +5,4 @@ pub mod currency_code;
 pub mod vat_category_code;
 pub mod identifier_scheme_code;
 pub mod unit_code;
+pub mod payment_means_code;

--- a/src/components/enums/payment_means_code.rs
+++ b/src/components/enums/payment_means_code.rs
@@ -1,0 +1,387 @@
+use serde::{Serialize, Serializer};
+
+// based on UNTDID 4461:
+// https://unece.org/fileadmin/DAM/trade/untdid/d16b/tred/tred4461.htm
+// https://www.xrepository.de/details/urn:xoev-de:xrechnung:codeliste:untdid.4461_1
+
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum PaymentMeansCode<'invoice> {
+    /// Not defined legally enforceable agreement between two or
+    /// more parties (expressing a contractual right or a right
+    /// to the payment of money).
+    InstrumentNotDefined,
+    /// A credit transaction made through the automated clearing
+    /// house system.
+    AutomatedClearingHouseCredit,
+    /// A debit transaction made through the automated clearing
+    /// house system.
+    AutomatedClearingHouseDebit,
+    /// A request to reverse an ACH debit transaction to a
+    /// demand deposit account.
+    AchDemandDebitReversal,
+    /// A request to reverse a credit transaction to a demand
+    /// deposit account.
+    AchDemandCreditReversal,
+    /// A credit transaction made through the ACH system to a
+    /// demand deposit account.
+    AchDemandCredit,
+    /// A debit transaction made through the ACH system to a
+    /// demand deposit account.
+    AchDemandDebit,
+    /// Indicates that the bank should hold the payment for
+    /// collection by the beneficiary or other instructions.
+    Hold,
+    /// Indicates that the payment should be made using the
+    /// national or regional clearing.
+    NationalOrRegionalClearing,
+    /// Payment by currency (including bills and coins) in
+    /// circulation, including checking account deposits.
+    InCash,
+    /// A request to reverse an ACH credit transaction to a
+    /// savings account.
+    AchSavingsCreditReversal,
+    /// A request to reverse an ACH debit transaction to a
+    /// savings account.
+    AchSavingsDebitReversal,
+    /// A credit transaction made through the ACH system to a
+    /// savings account.
+    AchSavingsCredit,
+    /// A debit transaction made through the ACH system to a
+    /// savings account.
+    AchSavingsDebit,
+    /// A credit entry between two accounts at the same bank
+    /// branch. Synonym: house credit.
+    BookentryCredit,
+    /// A debit entry between two accounts at the same bank
+    /// branch. Synonym: house debit.
+    BookentryDebit,
+    /// A credit transaction made through the ACH system to a
+    /// demand deposit account using the CCD payment format.
+    AchDemandCashConcentrationdisbursementCcdCredit,
+    /// A debit transaction made through the ACH system to a
+    /// demand deposit account using the CCD payment format.
+    AchDemandCashConcentrationdisbursementCcdDebit,
+    /// A credit transaction made through the ACH system to a
+    /// demand deposit account using the CTP payment format.
+    AchDemandCorporateTradePaymentCtpCredit,
+    /// Payment by a pre-printed form on which instructions are
+    /// given to an account holder (a bank or building society)
+    /// to pay a stated sum to a named recipient.
+    Cheque,
+    /// Issue of a banker's draft in payment of the funds.
+    BankersDraft,
+    /// Cheque drawn by a bank on itself or its agent. A person
+    /// who owes money to another buys the draft from a bank for
+    /// cash and hands it to the creditor who need have no fear
+    /// that it might be dishonoured.
+    CertifiedBankersDraft,
+    /// Payment by a pre-printed form, which has been completed
+    /// by a financial institution, on which instructions are
+    /// given to an account holder (a bank or building society)
+    /// to pay a stated sum to a named recipient.
+    BankChequeIssuedByABankingOrSimilarEstablishment,
+    /// Bill drawn by the creditor on the debtor but not yet
+    /// accepted by the debtor.
+    BillOfExchangeAwaitingAcceptance,
+    /// Payment by a pre-printed form stamped with the paying
+    /// bank's certification on which instructions are given to
+    /// an account holder (a bank or building society) to pay a
+    /// stated sum to a named recipient .
+    CertifiedCheque,
+    /// Indicates that the cheque is given local to the
+    /// recipient.
+    LocalCheque,
+    /// A debit transaction made through the ACH system to a
+    /// demand deposit account using the CTP payment format.
+    AchDemandCorporateTradePaymentCtpDebit,
+    /// A credit transaction made through the ACH system to a
+    /// demand deposit account using the CTX payment format.
+    AchDemandCorporateTradeExchangeCtxCredit,
+    /// A debit transaction made through the ACH system to a
+    /// demand account using the CTX payment format.
+    AchDemandCorporateTradeExchangeCtxDebit,
+    /// Payment by credit movement of funds from one account to
+    /// another.
+    CreditTransfer,
+    /// Payment by debit movement of funds from one account to
+    /// another.
+    DebitTransfer,
+    /// credit
+    /// A credit transaction made through the ACH system to a
+    /// demand deposit account using the CCD+ payment format.
+    AchDemandCashConcentrationdisbursementPlusCcdDebit,
+    /// A debit transaction made through the ACH system to a
+    /// demand deposit account using the CCD+ payment format.
+    AchDemandCashConcentrationdisbursementPlusCcdCredit,
+    /// A consumer credit transaction made through the ACH
+    /// system to a demand deposit or savings account.
+    AchPrearrangedPaymentAndDepositPpd,
+    /// A credit transaction made through the ACH system to a
+    /// demand deposit or savings account.
+    AchSavingsCashConcentrationdisbursementCcdCredit,
+    /// A debit transaction made through the ACH system to a
+    /// savings account using the CCD payment format.
+    AchSavingsCashConcentrationdisbursementCcdDebit,
+    /// A credit transaction made through the ACH system to a
+    /// savings account using the CTP payment format.
+    AchSavingsCorporateTradePaymentCtpCredit,
+    /// A debit transaction made through the ACH system to a
+    /// savings account using the CTP payment format.
+    AchSavingsCorporateTradePaymentCtpDebit,
+    /// A credit transaction made through the ACH system to a
+    /// savings account using the CTX payment format.
+    AchSavingsCorporateTradeExchangeCtxCredit,
+    /// A debit transaction made through the ACH system to a
+    /// savings account using the CTX payment format.
+    AchSavingsCorporateTradeExchangeCtxDebit,
+    /// credit
+    /// A credit transaction made through the ACH system to a
+    /// savings account using the CCD+ payment format.
+    AchSavingsCashConcentrationdisbursementPlusCcdCredit,
+    /// Payment by an arrangement for settling debts that is
+    /// operated by the Post Office.
+    PaymentToBankAccount,
+    /// debit
+    /// A debit transaction made through the ACH system to a
+    /// savings account using the CCD+ payment format.
+    AchSavingsCashConcentrationdisbursementPlusCcdDebit,
+    /// Bill drawn by the creditor on the debtor and accepted by
+    /// the debtor.
+    AcceptedBillOfExchange,
+    /// A referenced credit transfer initiated through home-
+    /// banking.
+    ReferencedHomebankingCreditTransfer,
+    /// A debit transfer via interbank means.
+    InterbankDebitTransfer,
+    /// A debit transfer initiated through home-banking.
+    HomebankingDebitTransfer,
+    /// Payment by means of a card issued by a bank or other
+    /// financial institution.
+    BankCard,
+    /// The amount is to be, or has been, directly debited to
+    /// the customer's bank account.
+    DirectDebit,
+    /// A method for the transmission of funds through the
+    /// postal system rather than through the banking system.
+    PaymentByPostgiro,
+    /// Banking Standards) - Option A
+    /// A French standard procedure that allows a debtor to pay
+    /// an amount due to a creditor. The creditor will forward
+    /// it to its bank, which will collect the money on the bank
+    /// account of the debtor.
+    FrNorme6_97telereglementCfonbFrenchOrganisationFor,
+    /// Payment order which requires guaranteed processing by
+    /// the most appropriate means to ensure it occurs on the
+    /// requested execution date, provided that it is issued to
+    /// the ordered bank before the agreed cut-off time.
+    UrgentCommercialPayment,
+    /// Payment order or transfer which must be executed, by the
+    /// most appropriate means, as urgently as possible and
+    /// before urgent commercial payments.
+    UrgentTreasuryPayment,
+    /// Payment made by means of credit card.
+    CreditCard,
+    /// Payment made by means of debit card.
+    DebitCard,
+    /// Payment will be, or has been, made by bankgiro.
+    Bankgiro,
+    /// The payment means have been previously agreed between
+    /// seller and buyer and thus are not stated again.
+    StandingAgreement,
+    /// Credit transfer inside the Single Euro Payment Area
+    /// (SEPA) system.
+    SepaCreditTransfer,
+    /// Direct debit inside the Single Euro Payment Area (SEPA)
+    /// system.
+    SepaDirectDebit,
+    /// Payment by an unconditional promise in writing made by
+    /// one person to another, signed by the maker, engaging to
+    /// pay on demand or at a fixed or determinable future time
+    /// a sum certain in money, to order or to bearer.
+    PromissoryNote,
+    /// Payment by an unconditional promise in writing made by
+    /// the debtor to another person, signed by the debtor,
+    /// engaging to pay on demand or at a fixed or determinable
+    /// future time a sum certain in money, to order or to
+    /// bearer.
+    PromissoryNoteSignedByTheDebtor,
+    /// Payment by an unconditional promise in writing made by
+    /// the debtor to another person, signed by the debtor and
+    /// endorsed by a bank, engaging to pay on demand or at a
+    /// fixed or determinable future time a sum certain in
+    /// money, to order or to bearer.
+    PromissoryNoteSignedByTheDebtorAndEndorsedByABank,
+    /// third party
+    /// Payment by an unconditional promise in writing made by
+    /// the debtor to another person, signed by the debtor and
+    /// endorsed by a third party, engaging to pay on demand or
+    /// at a fixed or determinable future time a sum certain in
+    /// money, to order or to bearer.
+    PromissoryNoteSignedByTheDebtorAndEndorsedByAThirdParty,
+    /// Payment by an unconditional promise in writing made by
+    /// the bank to another person, signed by the bank, engaging
+    /// to pay on demand or at a fixed or determinable future
+    /// time a sum certain in money, to order or to bearer.
+    PromissoryNoteSignedByABank,
+    /// Payment by an unconditional promise in writing made by
+    /// the bank to another person, signed by the bank and
+    /// endorsed by another bank, engaging to pay on demand or
+    /// at a fixed or determinable future time a sum certain in
+    /// money, to order or to bearer.
+    PromissoryNoteSignedByABankAndEndorsedByAnotherBank,
+    /// Payment by an unconditional promise in writing made by a
+    /// third party to another person, signed by the third
+    /// party, engaging to pay on demand or at a fixed or
+    /// determinable future time a sum certain in money, to
+    /// order or to bearer.
+    PromissoryNoteSignedByAThirdParty,
+    /// Payment by an unconditional promise in writing made by a
+    /// third party to another person, signed by the third party
+    /// and endorsed by a bank, engaging to pay on demand or at
+    /// a fixed or determinable future time a sum certain in
+    /// money, to order or to bearer.
+    PromissoryNoteSignedByAThirdPartyAndEndorsedByABank,
+    /// Payment will be made or has been made by an online
+    /// payment service.
+    OnlinePaymentService,
+    /// Bill drawn by the creditor on the debtor.
+    BillDrawnByTheCreditorOnTheDebtor,
+    /// Bill drawn by the creditor on a bank.
+    BillDrawnByTheCreditorOnABank,
+    /// Bill drawn by the creditor, endorsed by another bank.
+    BillDrawnByTheCreditorEndorsedByAnotherBank,
+    /// third party
+    /// Bill drawn by the creditor on a bank and endorsed by a
+    /// third party.
+    BillDrawnByTheCreditorOnABankAndEndorsedByAThirdParty,
+    /// Bill drawn by the creditor on a third party.
+    BillDrawnByTheCreditorOnAThirdParty,
+    /// endorsed by bank
+    /// Bill drawn by creditor on third party, accepted and
+    /// endorsed by bank.
+    BillDrawnByCreditorOnThirdPartyAcceptedAnd,
+    /// Issue a bankers draft not endorsable.
+    NotTransferableBankersDraft,
+    /// Issue a cheque not endorsable in payment of the funds.
+    NotTransferableLocalCheque,
+    /// Ordering customer tells the bank to use the payment
+    /// system 'Reference giro'. Used in the Finnish national
+    /// banking system.
+    ReferenceGiro,
+    /// Ordering customer tells the bank to use the bank service
+    /// 'Urgent Giro' when transferring the payment. Used in
+    /// Finnish national banking system.
+    UrgentGiro,
+    /// Ordering customer tells the ordering bank to use the
+    /// bank service 'Free Format Giro' when transferring the
+    /// payment. Used in Finnish national banking system.
+    FreeFormatGiro,
+    /// If the requested method for payment was or could not be
+    /// used, this code indicates that.
+    RequestedMethodForPaymentWasNotUsed,
+    /// Amounts which two partners owe to each other to be
+    /// compensated in order to avoid useless payments.
+    ClearingBetweenPartners,
+    /// A code assigned within a code list to be used on an
+    /// interim basis and as defined among trading partners
+    /// until a precise code can be assigned to the code list.
+    MutuallyDefined(&'invoice str),
+}
+
+impl<'invoice> PaymentMeansCode<'invoice> {
+    pub fn as_str(&self) -> &str {
+        match self {
+            PaymentMeansCode::InstrumentNotDefined => "1",
+            PaymentMeansCode::AutomatedClearingHouseCredit => "2",
+            PaymentMeansCode::AutomatedClearingHouseDebit => "3",
+            PaymentMeansCode::AchDemandDebitReversal => "4",
+            PaymentMeansCode::AchDemandCreditReversal => "5",
+            PaymentMeansCode::AchDemandCredit => "6",
+            PaymentMeansCode::AchDemandDebit => "7",
+            PaymentMeansCode::Hold => "8",
+            PaymentMeansCode::NationalOrRegionalClearing => "9",
+            PaymentMeansCode::InCash => "10",
+            PaymentMeansCode::AchSavingsCreditReversal => "11",
+            PaymentMeansCode::AchSavingsDebitReversal => "12",
+            PaymentMeansCode::AchSavingsCredit => "13",
+            PaymentMeansCode::AchSavingsDebit => "14",
+            PaymentMeansCode::BookentryCredit => "15",
+            PaymentMeansCode::BookentryDebit => "16",
+            PaymentMeansCode::AchDemandCashConcentrationdisbursementCcdCredit => "17",
+            PaymentMeansCode::AchDemandCashConcentrationdisbursementCcdDebit => "18",
+            PaymentMeansCode::AchDemandCorporateTradePaymentCtpCredit => "19",
+            PaymentMeansCode::Cheque => "20",
+            PaymentMeansCode::BankersDraft => "21",
+            PaymentMeansCode::CertifiedBankersDraft => "22",
+            PaymentMeansCode::BankChequeIssuedByABankingOrSimilarEstablishment => "23",
+            PaymentMeansCode::BillOfExchangeAwaitingAcceptance => "24",
+            PaymentMeansCode::CertifiedCheque => "25",
+            PaymentMeansCode::LocalCheque => "26",
+            PaymentMeansCode::AchDemandCorporateTradePaymentCtpDebit => "27",
+            PaymentMeansCode::AchDemandCorporateTradeExchangeCtxCredit => "28",
+            PaymentMeansCode::AchDemandCorporateTradeExchangeCtxDebit => "29",
+            PaymentMeansCode::CreditTransfer => "30",
+            PaymentMeansCode::DebitTransfer => "31",
+            PaymentMeansCode::AchDemandCashConcentrationdisbursementPlusCcdDebit => "32",
+            PaymentMeansCode::AchDemandCashConcentrationdisbursementPlusCcdCredit => "33",
+            PaymentMeansCode::AchPrearrangedPaymentAndDepositPpd => "34",
+            PaymentMeansCode::AchSavingsCashConcentrationdisbursementCcdCredit => "35",
+            PaymentMeansCode::AchSavingsCashConcentrationdisbursementCcdDebit => "36",
+            PaymentMeansCode::AchSavingsCorporateTradePaymentCtpCredit => "37",
+            PaymentMeansCode::AchSavingsCorporateTradePaymentCtpDebit => "38",
+            PaymentMeansCode::AchSavingsCorporateTradeExchangeCtxCredit => "39",
+            PaymentMeansCode::AchSavingsCorporateTradeExchangeCtxDebit => "40",
+            PaymentMeansCode::AchSavingsCashConcentrationdisbursementPlusCcdCredit => "41",
+            PaymentMeansCode::PaymentToBankAccount => "42",
+            PaymentMeansCode::AchSavingsCashConcentrationdisbursementPlusCcdDebit => "43",
+            PaymentMeansCode::AcceptedBillOfExchange => "44",
+            PaymentMeansCode::ReferencedHomebankingCreditTransfer => "45",
+            PaymentMeansCode::InterbankDebitTransfer => "46",
+            PaymentMeansCode::HomebankingDebitTransfer => "47",
+            PaymentMeansCode::BankCard => "48",
+            PaymentMeansCode::DirectDebit => "49",
+            PaymentMeansCode::PaymentByPostgiro => "50",
+            PaymentMeansCode::FrNorme6_97telereglementCfonbFrenchOrganisationFor => "51",
+            PaymentMeansCode::UrgentCommercialPayment => "52",
+            PaymentMeansCode::UrgentTreasuryPayment => "53",
+            PaymentMeansCode::CreditCard => "54",
+            PaymentMeansCode::DebitCard => "55",
+            PaymentMeansCode::Bankgiro => "56",
+            PaymentMeansCode::StandingAgreement => "57",
+            PaymentMeansCode::SepaCreditTransfer => "58",
+            PaymentMeansCode::SepaDirectDebit => "59",
+            PaymentMeansCode::PromissoryNote => "60",
+            PaymentMeansCode::PromissoryNoteSignedByTheDebtor => "61",
+            PaymentMeansCode::PromissoryNoteSignedByTheDebtorAndEndorsedByABank => "62",
+            PaymentMeansCode::PromissoryNoteSignedByTheDebtorAndEndorsedByAThirdParty => "63",
+            PaymentMeansCode::PromissoryNoteSignedByABank => "64",
+            PaymentMeansCode::PromissoryNoteSignedByABankAndEndorsedByAnotherBank => "65",
+            PaymentMeansCode::PromissoryNoteSignedByAThirdParty => "66",
+            PaymentMeansCode::PromissoryNoteSignedByAThirdPartyAndEndorsedByABank => "67",
+            PaymentMeansCode::OnlinePaymentService => "68",
+            PaymentMeansCode::BillDrawnByTheCreditorOnTheDebtor => "70",
+            PaymentMeansCode::BillDrawnByTheCreditorOnABank => "74",
+            PaymentMeansCode::BillDrawnByTheCreditorEndorsedByAnotherBank => "75",
+            PaymentMeansCode::BillDrawnByTheCreditorOnABankAndEndorsedByAThirdParty => "76",
+            PaymentMeansCode::BillDrawnByTheCreditorOnAThirdParty => "77",
+            PaymentMeansCode::BillDrawnByCreditorOnThirdPartyAcceptedAnd => "78",
+            PaymentMeansCode::NotTransferableBankersDraft => "91",
+            PaymentMeansCode::NotTransferableLocalCheque => "92",
+            PaymentMeansCode::ReferenceGiro => "93",
+            PaymentMeansCode::UrgentGiro => "94",
+            PaymentMeansCode::FreeFormatGiro => "95",
+            PaymentMeansCode::RequestedMethodForPaymentWasNotUsed => "96",
+            PaymentMeansCode::ClearingBetweenPartners => "97",
+            PaymentMeansCode::MutuallyDefined(v) => v,
+        }
+    }
+}
+
+impl<'invoice> Serialize for PaymentMeansCode<'invoice> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}

--- a/src/components/enums/specification_level.rs
+++ b/src/components/enums/specification_level.rs
@@ -6,7 +6,8 @@ pub enum SpecificationLevel {
     BasicWithoutLines,
     Basic,
     En16931,
-    Extended
+    XRechnung,
+    Extended,
 }
 
 impl SpecificationLevel {
@@ -17,6 +18,7 @@ impl SpecificationLevel {
             SpecificationLevel::Basic => "urn:cen.eu:en16931:2017#compliant#urn:factur-x.eu:1p0:basic",
             SpecificationLevel::En16931 => "urn:cen.eu:en16931:2017",
             SpecificationLevel::Extended => "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended",
+            SpecificationLevel::XRechnung => "urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0"
         }
     }
 }

--- a/src/components/structs.rs
+++ b/src/components/structs.rs
@@ -445,13 +445,16 @@ pub struct ApplicableTradeTax <'invoice> {
     pub calculated_amount: Option<f64>,
     #[serde(rename="ram:TypeCode")]
     pub type_code: &'invoice str,
+    #[serde(rename="ram:ExemptionReason", skip_serializing_if = "Option::is_none")]
+    pub exemption_reason: Option<&'invoice str>,
     #[serde(rename="ram:BasisAmount",serialize_with="format_f64_option", skip_serializing_if = "Option::is_none")]
     pub basis_amount: Option<f64>,
     #[serde(rename="ram:CategoryCode")]
     pub category_code: VATCategoryCode,
+    #[serde(rename="ram:ExemptionReasonCode", skip_serializing_if = "Option::is_none")]
+    pub exemption_reason_code: Option<&'invoice str>,
     #[serde(rename="ram:RateApplicablePercent",serialize_with="format_f64_option", skip_serializing_if = "Option::is_none")]
     pub rate_applicable_percent: Option<f64>,
-
 }
 
 impl<'invoice> Default for ApplicableTradeTax<'invoice> {
@@ -462,6 +465,8 @@ impl<'invoice> Default for ApplicableTradeTax<'invoice> {
             basis_amount: None,
             category_code: VATCategoryCode::StandardRate,
             rate_applicable_percent: None,
+            exemption_reason: None,
+            exemption_reason_code: None,
         }
     }
 }

--- a/src/components/structs.rs
+++ b/src/components/structs.rs
@@ -379,6 +379,12 @@ impl<'invoice> SpecifiedTaxRegistrationID<'invoice> {
             value,
         }
     }
+    pub fn new_fc(value: &'invoice str) -> Self {
+        Self {
+            scheme_id: "FC",
+            value,
+        }
+    }
 }
 
 #[derive(Serialize, Clone, Debug)]

--- a/src/components/structs.rs
+++ b/src/components/structs.rs
@@ -9,6 +9,7 @@ use crate::components::enums::{
     vat_category_code::VATCategoryCode,
     identifier_scheme_code::IdentifierSchemeCode,
     unit_code::UnitCode,
+    payment_means_code::PaymentMeansCode,
 };
 
 use crate::components::constants;
@@ -431,13 +432,59 @@ impl<'invoice> ApplicableHeaderTradeDelivery<'invoice> {
 pub struct ApplicableHeaderTradeSettlement <'invoice>{
     #[serde(rename="ram:InvoiceCurrencyCode")]
     pub invoice_currency_code: CurrencyCode,
+    #[serde(rename="ram:SpecifiedTradeSettlementPaymentMeans")]
+    pub specified_trade_settlement_payment_means: Vec<SpecifiedTradeSettlementPaymentMeans<'invoice>>,
     #[serde(rename="ram:ApplicableTradeTax", skip_serializing_if = "Option::is_none")]
     pub applicable_trade_tax: Option<ApplicableTradeTax<'invoice>>,
     #[serde(rename="ram:SpecifiedTradePaymentTerms", skip_serializing_if = "Option::is_none")]
     pub specified_trade_payment_terms: Option<SpecifiedTradePaymentTerms<'invoice>>,
     #[serde(rename="ram:SpecifiedTradeSettlementHeaderMonetarySummation")]
     pub specified_trade_settlement_header_monetary_summation: SpecifiedTradeSettlementHeaderMonetarySummation,
-}   
+}
+
+#[derive(Serialize, Clone, Copy, Debug)]
+pub struct SpecifiedTradeSettlementPaymentMeans<'invoice> {
+    #[serde(rename="ram:TypeCode")]
+    pub type_code: PaymentMeansCode<'invoice>,
+    #[serde(rename="ram:Information", skip_serializing_if = "Option::is_none")]
+    pub information: Option<&'invoice str>,
+    #[serde(rename="ram:Information", skip_serializing_if = "Option::is_none")]
+    pub applicable_trade_settlement_financial_card: Option<&'invoice str>,
+    #[serde(rename="ram:PayerPartyDebtorFinancialAccount", skip_serializing_if = "Option::is_none")]
+    pub payer_party_debtor_financial_account: Option<PayerPartyDebtorFinancialAccount<'invoice>>,
+    #[serde(rename="ram:PayeePartyCreditorFinancialAccount", skip_serializing_if = "Option::is_none")]
+    pub payee_party_creditor_financial_account: Option<PayeePartyCreditorFinancialAccount<'invoice>>,
+    #[serde(rename="ram:PayeeSpecifiedCreditorFinancialInstitution", skip_serializing_if = "Option::is_none")]
+    pub payee_specified_creditor_financial_institution: Option<PayeeSpecifiedCreditorFinancialInstitution<'invoice>>
+}
+
+#[derive(Serialize, Clone, Copy, Debug)]
+pub struct ApplicableTradeSettlementFinancialCard<'invoice> {
+    pub id: &'invoice str, // TODO: should this be an enum?
+    pub cardholder_name: &'invoice str,
+}
+
+#[derive(Serialize, Clone, Copy, Debug)]
+pub struct PayerPartyDebtorFinancialAccount<'invoice> {
+    #[serde(rename="ram:IBANID")]
+    pub ibanid: &'invoice str,
+}
+
+#[derive(Serialize, Clone, Copy, Debug)]
+pub struct PayeePartyCreditorFinancialAccount<'invoice> {
+    #[serde(rename="ram:IBANID", skip_serializing_if = "Option::is_none")]
+    pub ibanid: Option<&'invoice str>, // TODO: should this be a custom type? Or the crate `iban`?
+    #[serde(rename="ram:AccountName", skip_serializing_if = "Option::is_none")]
+    pub account_name: Option<&'invoice str>, // TODO: should this be a custom type? Or the crate `iban`?
+    #[serde(rename="ram:ProprietaryID", skip_serializing_if = "Option::is_none")]
+    pub proprietary_id: Option<&'invoice str>,
+}
+
+#[derive(Serialize, Clone, Copy, Debug)]
+pub struct PayeeSpecifiedCreditorFinancialInstitution<'invoice> {
+    #[serde(rename="ram:BICID")]
+    pub bicid: &'invoice str
+}
 
 #[derive(Serialize, Clone, Copy, Debug)]
 pub struct ApplicableTradeTax <'invoice> {

--- a/src/components/structs.rs
+++ b/src/components/structs.rs
@@ -197,9 +197,11 @@ pub struct SpecifiedTradeProduct<'invoice> {
     /// BT-157
     pub global_id: Option<GlobalID<'invoice>>,
     #[serde(rename="ram:Name")]
+    /// BT-153
     pub name: &'invoice str,
-    //#[serde(rename="ram:Description")]
-    //pub description: &'invoice str,
+    #[serde(rename="ram:Description", skip_serializing_if = "Option::is_none")]
+    /// BT-154
+    pub description: Option<&'invoice str>,
 }
 
 #[derive(Serialize, Clone, Debug)]
@@ -285,20 +287,27 @@ pub struct ApplicableHeaderTradeAgreement<'invoice> {
     pub seller_trade_party: SellerTradeParty<'invoice>,
     #[serde(rename="ram:BuyerTradeParty")]
     pub buyer_trade_party: BuyerTradeParty<'invoice>,
-    #[serde(rename="ram:BuyerOrderReferencedDocument")]
-    pub buyer_order_referenced_document: BuyerOrderReferencedDocument<'invoice>,
+    #[serde(rename="ram:BuyerOrderReferencedDocument", skip_serializing_if = "Option::is_none")]
+    pub buyer_order_referenced_document: Option<BuyerOrderReferencedDocument<'invoice>>,
 }
 
 #[derive(Serialize, Clone, Debug)]
 pub struct SellerTradeParty<'invoice> {
+    #[serde(rename="ram:ID")]
+    pub id: Vec<&'invoice str>,
+    #[serde(rename="ram:GlobalID")]
+    pub global_id: Vec<GlobalID<'invoice>>,
     #[serde(rename="ram:Name")]
     pub name: &'invoice str,
-    #[serde(rename="ram:SpecifiedLegalOrganization")]
-    pub specified_legal_organization: SpecifiedLegalOrganization<'invoice>,
+    #[serde(rename="ram:SpecifiedLegalOrganization", skip_serializing_if = "Option::is_none")]
+    pub specified_legal_organization: Option<SpecifiedLegalOrganization<'invoice>>,
     #[serde(rename="ram:PostalTradeAddress")]
     pub postal_trade_address: PostalTradeAddress<'invoice>,
+    #[serde(rename="ram:URIUniversalCommunication", skip_serializing_if = "Option::is_none")]
+    /// BT-34-00
+    pub uri_universal_communication: Option<URIUniversalCommunication<'invoice>>,
     #[serde(rename="ram:SpecifiedTaxRegistration")]
-    pub specified_tax_registration: SpecifiedTaxRegistration<'invoice>,
+    pub specified_tax_registration: Vec<SpecifiedTaxRegistration<'invoice>>,
 }
 
 #[derive(Serialize, Clone, Debug)]
@@ -376,6 +385,20 @@ impl<'invoice> SpecifiedTaxRegistrationID<'invoice> {
 pub struct SpecifiedTaxRegistration<'invoice> {
     #[serde(rename="ram:ID")]
     pub id: SpecifiedTaxRegistrationID<'invoice>,
+}
+
+#[derive(Serialize, Clone, Debug)]
+pub struct URIUniversalCommunication<'invoice> {
+    #[serde(rename="ram:URIID")]
+    pub uriid: UriId<'invoice>,
+}
+
+#[derive(Serialize, Clone, Debug)]
+pub struct UriId<'invoice> {
+    #[serde(rename="@schemeID")]
+    pub scheme_id: &'invoice str,    
+    #[serde(rename="$value")]
+    pub value: &'invoice str,
 }
 
 #[derive(Serialize, Clone, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,9 +93,6 @@ impl<'invoice_builder> InvoiceBuilder <'invoice_builder> {
         if self.sellers_name.is_none() {
             error_text += "Seller's name not set\n";
         }
-        if self.sellers_specified_legal_organization.is_none() {
-            error_text += "Seller's specified legal organization not set\n";
-        }
         if self.sellers_postal_trade_address.country_id == CountryCode::NotSet {
             error_text += "Seller's postal trade address country code not set\n";
         }
@@ -104,9 +101,6 @@ impl<'invoice_builder> InvoiceBuilder <'invoice_builder> {
         }
         if self.buyers_name.is_none() {
             error_text += "Buyer's name not set\n";
-        }
-        if self.buyers_specified_legal_organization.is_none() {
-            error_text += "Buyer's specified legal organization not set\n";
         }
         if self.buyers_order_specified_document.is_none() {
             error_text += "Buyer's order specified document not set\n";
@@ -209,6 +203,12 @@ impl<'invoice_builder> InvoiceBuilder <'invoice_builder> {
         if specification_level >= SpecificationLevel::Extended {
             if self.buyer_reference.is_none() {
                 error_text += "Buyer reference not set\n";
+            }
+            if self.sellers_specified_legal_organization.is_none() {
+                error_text += "Seller's specified legal organization not set\n";
+            }
+            if self.buyers_specified_legal_organization.is_none() {
+                error_text += "Buyer's specified legal organization not set\n";
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -547,6 +547,7 @@ impl<'invoice_builder> InvoiceBuilder <'invoice_builder> {
                 },
                 applicable_header_trade_settlement: ApplicableHeaderTradeSettlement {
                     invoice_currency_code: self.invoice_currency_code.clone().unwrap(),
+                    specified_trade_settlement_payment_means: Vec::new(),
                     applicable_trade_tax: self.applicable_trade_tax,
                     specified_trade_payment_terms: self.specified_trade_payment_terms.clone(),
                     specified_trade_settlement_header_monetary_summation: self.monetary_summation.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -502,10 +502,14 @@ impl<'invoice_builder> InvoiceBuilder <'invoice_builder> {
                 applicable_header_trade_agreement: ApplicableHeaderTradeAgreement {
                     buyer_reference: self.buyer_reference,
                     seller_trade_party: SellerTradeParty {
+                        id: Vec::new(),
+                        global_id: Vec::new() ,
                         name: self.sellers_name.unwrap(),
-                        specified_legal_organization: SpecifiedLegalOrganization {
-                            id: LegalOrganizationID::new(self.sellers_specified_legal_organization.unwrap()),
-                        },
+                        specified_legal_organization: self.sellers_specified_legal_organization.map(|v|
+                            SpecifiedLegalOrganization {
+                                id: LegalOrganizationID::new(v),
+                            }
+                        ),
                         postal_trade_address: PostalTradeAddress {
                             country_id: self.sellers_postal_trade_address.country_id,
                             postcode_code: self.sellers_postal_trade_address.postcode_code,
@@ -514,9 +518,12 @@ impl<'invoice_builder> InvoiceBuilder <'invoice_builder> {
                             line_three: self.sellers_postal_trade_address.line_three,
                             city_name: self.sellers_postal_trade_address.city_name,
                         },
-                        specified_tax_registration: SpecifiedTaxRegistration {
-                            id: SpecifiedTaxRegistrationID::new(self.sellers_specified_tax_registration.unwrap()),
-                        },
+                        uri_universal_communication: None,
+                        specified_tax_registration: vec![
+                            SpecifiedTaxRegistration {
+                                id: SpecifiedTaxRegistrationID::new(self.sellers_specified_tax_registration.unwrap()),
+                            }
+                        ],
                     },
                     buyer_trade_party: BuyerTradeParty {
                         name: self.buyers_name.unwrap(),
@@ -532,9 +539,11 @@ impl<'invoice_builder> InvoiceBuilder <'invoice_builder> {
                             city_name: self.buyers_postal_trade_address.city_name,
                         },
                     },
-                    buyer_order_referenced_document: BuyerOrderReferencedDocument {
-                        issuer_assigned_id: self.buyers_order_specified_document.unwrap(),
-                    },
+                    buyer_order_referenced_document: self.buyers_order_specified_document.map(|v|
+                        BuyerOrderReferencedDocument {
+                            issuer_assigned_id: v,
+                        }
+                    ),
                 },
                 applicable_header_trade_delivery: ApplicableHeaderTradeDelivery {
                     actual_delivery_supply_chain_event: Some(ActualDeliverySupplyChainEvent {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,9 +90,6 @@ impl<'invoice_builder> InvoiceBuilder <'invoice_builder> {
         if self.date_of_issue.is_none() {
             error_text += "Date of issue not set\n";
         }
-        if self.buyer_reference.is_none() {
-            error_text += "Buyer reference not set\n";
-        }
         if self.sellers_name.is_none() {
             error_text += "Seller's name not set\n";
         }
@@ -206,6 +203,12 @@ impl<'invoice_builder> InvoiceBuilder <'invoice_builder> {
         if specification_level >= SpecificationLevel::Basic {
             if self.included_supply_chain_trade_line_items.is_empty() {
                 error_text += "No included supply chain trade line items set\n";
+            }
+        }
+
+        if specification_level >= SpecificationLevel::Extended {
+            if self.buyer_reference.is_none() {
+                error_text += "Buyer reference not set\n";
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,6 +113,7 @@ fn main() {
                 scheme_id: IdentifierSchemeCode::GTIN,
             }),
             name: "Product 1",
+            description: None,
         },
         specified_line_trade_agreement:SpecifiedLineTradeAgreement {
             gross_price_product_trade_price: None,
@@ -153,6 +154,7 @@ fn main() {
                 scheme_id: IdentifierSchemeCode::GTIN,
             }),
             name: "Product 2",
+            description: Some("This is an interesting second product."),
         },
         specified_line_trade_agreement:SpecifiedLineTradeAgreement {
             gross_price_product_trade_price: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,6 +133,8 @@ fn main() {
                 category_code: zugferd::VATCategoryCode::StandardRate,
                 basis_amount: Some(100.0),
                 rate_applicable_percent: Some(19.0),
+                exemption_reason: None,
+                exemption_reason_code: None,
             },
             specified_trade_settlement_line_monetary_summation: SpecifiedTradeSettlementLineMonetarySummation {
                 line_total_amount: 119.0,
@@ -171,6 +173,8 @@ fn main() {
                 category_code: zugferd::VATCategoryCode::StandardRate,
                 basis_amount: Some(44.0),
                 rate_applicable_percent: Some(19.0),
+                exemption_reason: None,
+                exemption_reason_code: None,
             },
             specified_trade_settlement_line_monetary_summation: SpecifiedTradeSettlementLineMonetarySummation {
                 line_total_amount: (44.0*1.19),


### PR DESCRIPTION
This PR includes some changes that enabled me to generate valid ZUGFeRD invoices for a small business (Kleinunternehmerregelung gem. § 19 UStG) (confirmed working with Mustangproject)

- make these fields optional (in compliance with the spec):
  - `ApplicableHeaderTradeAgreement` -> `ram:BuyerOrderReferencedDocument`
  - `SellerTradeParty` -> `ram:SpecifiedLegalOrganization`
- add optional fields:
  - `SpecifiedTradeProduct` -> `ram:Description` (BT-154)
  - `SellerTradeParty` ->
    - `ram:ID` (BT-29)
    - `ram:GlobalID` (BT-29-0)
    - `ram:URIUniversalCommunication` (BT-34-00)
  - `ram:ApplicableTradeTax` -> 
    - `ram:ExemptionReason` (BT-120)
    - `ram:ExemptionReasonCode` (BT-121)
- `ram:SpecifiedTaxRegistration` is now a `Vec` (as defined in the spec)
- add `ram:SpecifiedTradeSettlementPaymentMeans`
- add specification level XRechnung
- allow creating tax registration IDs with scheme FC (e. g. German tax id for small businesses without a VAT ID)
- modify builder validation rules:
  - according to the provided sample files, `ram:SpecifiedLegalOrganization` and `ram:BuyerReference` are not required in Minimum, Basic, Basic WL and En16931