### PR TITLE
Fix the country-code round-trip test

### DIFF
--- a/src/components/enums/country_code.rs
+++ b/src/components/enums/country_code.rs
@@ -874,7 +874,6 @@ mod tests {
 
         let string_repr = code.as_str().to_owned();
         let parsed_code = CountryCode::try_from(string_repr.as_str()).unwrap();
-        debug_assert_eq!(parsed_code, code);
-        panic!("wtf")
+        assert_eq!(parsed_code, code);
     }
 }


### PR DESCRIPTION
The test asserted the `CountryCode` round-trip and then unconditionally panicked, so it always failed. Drop the leftover panic and promote the round-trip check to `assert_eq!`.