### PR TITLE
Fix clippy warnings

### DIFF
--- a/examples/01_minimum/main.rs
+++ b/examples/01_minimum/main.rs
@@ -8,7 +8,7 @@ fn main() {
         .set_business_process("process1")
         .set_invoice_type_code(InvoiceTypeCode::CommercialInvoice)
         .set_invoice_nr("INV-123456")
-        .set_date_of_issue(chrono::NaiveDate::from_ymd_opt(2024, 08, 10).unwrap())
+        .set_date_of_issue(chrono::NaiveDate::from_ymd_opt(2024, 8, 10).unwrap())
         .set_buyer_reference("BR-7890")
         .set_sellers_name("Seller Corp.")
         .set_sellers_specified_legal_organization("LegalOrg-001")

--- a/src/components/business_rules.rs
+++ b/src/components/business_rules.rs
@@ -9,8 +9,11 @@ pub struct BusinessRuleViolation {
     pub fields: Vec<(String, String)>,
 }
 
+/// A single business-rule check.
+type BusinessRule = fn(&Invoice) -> Result<(), BusinessRuleViolation>;
+
 /// List of business rules to validate
-const BUSINESS_RULES: &[fn(&Invoice) -> Result<(), BusinessRuleViolation>] = &[
+const BUSINESS_RULES: &[BusinessRule] = &[
     // br_01,
     // br_02,
     // br_03,

--- a/src/components/functions.rs
+++ b/src/components/functions.rs
@@ -17,8 +17,8 @@ pub fn write_xml_to_file (
     match OpenOptions::new().write(true).create(true).truncate(true).open(path) {
         Ok(mut file) => {
             file.write_all(xml_content.as_bytes()).map_err(|e| e.to_string())?;
-            return Ok(());
+            Ok(())
         },
-        Err(e) => return Err(e.to_string()),
-    };
+        Err(e) => Err(e.to_string()),
+    }
 }

--- a/src/components/structs.rs
+++ b/src/components/structs.rs
@@ -31,15 +31,15 @@ where S:Serializer
 {
     if option.is_some() {
         let formatted = format!("{:.2}",option.unwrap());
-        return serializer.serialize_str(&formatted);
+        serializer.serialize_str(&formatted)
     }
     else {
-        return serializer.serialize_none();
+        serializer.serialize_none()
         //return Err(serde::ser::Error::custom("Expected a value, got None"));
     }
 }
 
-fn vector_is_empty <S> (vector: &Vec<S>) -> bool {
+fn vector_is_empty <S> (vector: &[S]) -> bool {
     vector.is_empty()
 }
 
@@ -703,6 +703,7 @@ pub struct DueDateDateTime<'invoice> {
 
 /// `BG-22`: A group of business terms providing the monetary totals for the Invoice.
 #[derive(Serialize, Clone, Debug)]
+#[derive(Default)]
 pub struct SpecifiedTradeSettlementHeaderMonetarySummation {
     /// `BT-106`: Sum of all Invoice line net amounts in the Invoice.
     #[serde(rename="ram:LineTotalAmount", serialize_with="format_f64_option", skip_serializing_if = "Option::is_none")]
@@ -731,19 +732,6 @@ pub struct SpecifiedTradeSettlementHeaderMonetarySummation {
     pub due_payable_amount: Option<f64>,
 }
 
-impl Default for SpecifiedTradeSettlementHeaderMonetarySummation {
-    fn default() -> Self {
-        Self {
-            line_total_amount: None,
-            charge_total_amount: None,
-            allowance_total_amount: None,
-            tax_basis_total_amount: None,
-            tax_total_amount: None,
-            grand_total_amount: None,
-            due_payable_amount: None,
-        }
-    }
-}
 
 #[derive(Serialize, Clone, Debug)]
 pub struct TaxTotalAmount {
@@ -756,8 +744,8 @@ pub struct TaxTotalAmount {
 impl TaxTotalAmount {
     pub fn new(currency_id: CurrencyCode, amount: f64) -> Self {
         TaxTotalAmount {
-            currency_id: currency_id,
-            amount: amount,
+            currency_id,
+            amount,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,12 @@ pub struct InvoiceBuilder<'invoice_builder> {
     included_supply_chain_trade_line_items: Vec<IncludedSupplyChainTradeLineItem<'invoice_builder>>,
 }
 
+impl<'invoice_builder> Default for InvoiceBuilder<'invoice_builder> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<'invoice_builder> InvoiceBuilder<'invoice_builder> {
     pub fn new() -> Self {
         Self {
@@ -257,11 +263,10 @@ impl<'invoice_builder> InvoiceBuilder<'invoice_builder> {
             }
         }
 
-        if specification_level >= SpecificationLevel::Basic {
-            if self.included_supply_chain_trade_line_items.is_empty() {
+        if specification_level >= SpecificationLevel::Basic
+            && self.included_supply_chain_trade_line_items.is_empty() {
                 error_text += "No included supply chain trade line items set\n";
             }
-        }
 
         if specification_level >= SpecificationLevel::Extended {
             if self.buyer_reference.is_none() {
@@ -565,9 +570,10 @@ impl<'invoice_builder> InvoiceBuilder<'invoice_builder> {
         if let Some(applicable_trade_tax) = self.applicable_trade_tax.as_mut() {
             applicable_trade_tax.calculated_amount = Some(amount);
         } else {
-            let mut new_struct = ApplicableTradeTax::default();
-            new_struct.calculated_amount = Some(amount);
-            self.applicable_trade_tax = Some(new_struct);
+            self.applicable_trade_tax = Some(ApplicableTradeTax {
+                calculated_amount: Some(amount),
+                ..Default::default()
+            });
         }
 
         self
@@ -579,9 +585,10 @@ impl<'invoice_builder> InvoiceBuilder<'invoice_builder> {
         if let Some(applicable_trade_tax) = self.applicable_trade_tax.as_mut() {
             applicable_trade_tax.basis_amount = Some(amount);
         } else {
-            let mut new_struct = ApplicableTradeTax::default();
-            new_struct.basis_amount = Some(amount);
-            self.applicable_trade_tax = Some(new_struct);
+            self.applicable_trade_tax = Some(ApplicableTradeTax {
+                basis_amount: Some(amount),
+                ..Default::default()
+            });
         }
 
         self
@@ -594,9 +601,10 @@ impl<'invoice_builder> InvoiceBuilder<'invoice_builder> {
         if let Some(applicable_trade_tax) = self.applicable_trade_tax.as_mut() {
             applicable_trade_tax.category_code = code;
         } else {
-            let mut new_struct = ApplicableTradeTax::default();
-            new_struct.category_code = code;
-            self.applicable_trade_tax = Some(new_struct);
+            self.applicable_trade_tax = Some(ApplicableTradeTax {
+                category_code: code,
+                ..Default::default()
+            });
         }
 
         self
@@ -608,9 +616,10 @@ impl<'invoice_builder> InvoiceBuilder<'invoice_builder> {
         if let Some(applicable_trade_tax) = self.applicable_trade_tax.as_mut() {
             applicable_trade_tax.rate_applicable_percent = Some(amount);
         } else {
-            let mut new_struct = ApplicableTradeTax::default();
-            new_struct.rate_applicable_percent = Some(amount);
-            self.applicable_trade_tax = Some(new_struct);
+            self.applicable_trade_tax = Some(ApplicableTradeTax {
+                rate_applicable_percent: Some(amount),
+                ..Default::default()
+            });
         }
 
         self
@@ -806,7 +815,7 @@ impl<'invoice_builder> InvoiceBuilder<'invoice_builder> {
                     }),
                 },
                 applicable_header_trade_settlement: ApplicableHeaderTradeSettlement {
-                    invoice_currency_code: self.invoice_currency_code.clone().unwrap(),
+                    invoice_currency_code: self.invoice_currency_code.unwrap(),
                     specified_trade_settlement_payment_means: Vec::new(),
                     applicable_trade_tax: self.applicable_trade_tax,
                     specified_trade_allowance_charge: Vec::new(),
@@ -840,7 +849,7 @@ mod test {
             .set_business_process("process1")
             .set_invoice_type_code(InvoiceTypeCode::CommercialInvoice)
             .set_invoice_nr("INV-123456")
-            .set_date_of_issue(chrono::NaiveDate::from_ymd_opt(2024, 08, 10).unwrap())
+            .set_date_of_issue(chrono::NaiveDate::from_ymd_opt(2024, 8, 10).unwrap())
             .set_buyer_reference("BR-7890")
             .set_sellers_name("Seller Corp.")
             // .set_sellers_specified_legal_organization("LegalOrg-001")

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ fn main() {
     invoice_builder.set_business_process("process1")
                     .set_invoice_type_code(InvoiceTypeCode::CommercialInvoice)
                     .set_invoice_nr("INV-123456")
-                    .set_date_of_issue(chrono::NaiveDate::from_ymd_opt(2024,08,10).unwrap())
+                    .set_date_of_issue(chrono::NaiveDate::from_ymd_opt(2024,8,10).unwrap())
                     .set_buyer_reference("BR-7890")
                     .set_sellers_name("Seller Corp.")
                     .set_sellers_specified_legal_organization("LegalOrg-001")
@@ -87,7 +87,7 @@ fn main() {
         .set_buyers_postal_trade_address_city_name("Springfield");
 
     invoice_builder
-        .set_occurrence_date(chrono::NaiveDate::from_ymd_opt(2024,07,06).unwrap());
+        .set_occurrence_date(chrono::NaiveDate::from_ymd_opt(2024,7,6).unwrap());
 
     invoice_builder
         .set_applicable_trade_tax_basis_amount(sum_net)


### PR DESCRIPTION
Make the crate pass `cargo clippy --all-targets -- -D warnings`. Notable manual changes: struct-literal initialisation instead of default-then-assign, `&[T]` parameters instead of `&Vec<T>`, a `BusinessRule` type alias for the rule list, and date literals without leading zeros; the remaining lints came from `cargo clippy --fix`.